### PR TITLE
Add new joint state initialization function

### DIFF
--- a/dsvedit/skeleton_editor_dialog.rb
+++ b/dsvedit/skeleton_editor_dialog.rb
@@ -202,7 +202,7 @@ class SkeletonEditorDialog < Qt::Dialog
       joint_change = pose.joint_changes[joint_index]
       
       joint_state.inherited_rotation = joint_change.rotation
-      joint_state.connected_rotation = joint_change.rotation
+      joint_state.relative_rotation = joint_change.rotation
       
       if joint.parent_id != 0xFF
         parent_joint = @skeleton.joints[joint.parent_id]
@@ -211,7 +211,7 @@ class SkeletonEditorDialog < Qt::Dialog
         if joint.copy_parent_visual_rotation # maybe this variable should be called something like "is_mobile" or "is_turning"
           joint_state.inherited_rotation += parent_joint_state.inherited_rotation
         else
-          joint_state.connected_rotation -= parent_joint_state.inherited_rotation
+          joint_state.relative_rotation -= parent_joint_state.inherited_rotation
         end
       end
       
@@ -532,5 +532,5 @@ class JointState
   attr_accessor :x_pos,
                 :y_pos,
                 :inherited_rotation,
-                :connected_rotation
+                :relative_rotation
 end

--- a/dsvedit/skeleton_editor_dialog.rb
+++ b/dsvedit/skeleton_editor_dialog.rb
@@ -233,12 +233,6 @@ class SkeletonEditorDialog < Qt::Dialog
           joint_state.y_pos = 0
       end
       
-      # workaround for functions that need absolute positions
-      if joint.parent_id != 0xFF
-        joint_state.x_pos += parent_joint_state.x_pos
-        joint_state.y_pos += parent_joint_state.y_pos
-      end
-      
       joint_states_for_pose << joint_state
     end
   end

--- a/dsvedit/skeleton_editor_dialog.rb
+++ b/dsvedit/skeleton_editor_dialog.rb
@@ -193,6 +193,56 @@ class SkeletonEditorDialog < Qt::Dialog
     
   end
   
+  def initialize_joint_states_new(pose)
+    joint_states_for_pose = []
+    
+    for joint_index in 0...pose.joint_changes.count
+      joint_state = JointState.new
+      joint = @skeleton.joints[joint_index]
+      joint_change = pose.joint_changes[joint_index]
+      
+      joint_state.inherited_rotation = joint_change.rotation
+      joint_state.connected_rotation = joint_change.rotation
+      
+      if joint.parent_id != 0xFF
+        parent_joint = @skeleton.joints[joint.parent_id]
+        parent_joint_state = joint_states_for_pose[joint.parent_id]
+        
+        if joint.copy_parent_visual_rotation # maybe this variable should be called something like "is_mobile" or "is_turning"
+          joint_state.inherited_rotation += parent_joint_state.inherited_rotation
+        else
+          joint_state.connected_rotation -= parent_joint_state.inherited_rotation
+        end
+      end
+      
+      case joint.positional_rotation
+        when 0
+          joint_state.x_pos = joint_change.distance
+          joint_state.y_pos = 0
+        when 1
+          joint_state.x_pos = 0
+          joint_state.y_pos = joint_change.distance
+        when 2
+          joint_state.x_pos = joint_change.distance * -1
+          joint_state.y_pos = 0
+        when 3
+          joint_state.x_pos = 0
+          joint_state.y_pos = joint_change.distance * -1
+        else # just to be safe
+          joint_state.x_pos = 0
+          joint_state.y_pos = 0
+      end
+      
+      # workaround for functions that need absolute positions
+      if joint.parent_id != 0xFF
+        joint_state.x_pos += parent_joint_state.x_pos
+        joint_state.y_pos += parent_joint_state.y_pos
+      end
+      
+      joint_states_for_pose << joint_state
+    end
+  end
+  
   def tween_poses(previous_pose, next_pose, tweening_progress)
     tweened_pose = Pose.new
     previous_pose.joint_changes.each_with_index do |prev_joint_change, joint_index|
@@ -487,5 +537,6 @@ end
 class JointState
   attr_accessor :x_pos,
                 :y_pos,
-                :inherited_rotation
+                :inherited_rotation,
+                :connected_rotation
 end

--- a/dsvlib/spriter_interface.rb
+++ b/dsvlib/spriter_interface.rb
@@ -297,7 +297,7 @@ class SpriterInterface
       joint_change = pose.joint_changes[joint_index]
       
       joint_state.inherited_rotation = joint_change.rotation
-      joint_state.connected_rotation = joint_change.rotation
+      joint_state.relative_rotation = joint_change.rotation
       
       if joint.parent_id != 0xFF
         parent_joint = skeleton.joints[joint.parent_id]
@@ -306,7 +306,7 @@ class SpriterInterface
         if joint.copy_parent_visual_rotation # maybe this variable should be called something like "is_mobile" or "is_turning"
           joint_state.inherited_rotation += parent_joint_state.inherited_rotation
         else
-          joint_state.connected_rotation -= parent_joint_state.inherited_rotation
+          joint_state.relative_rotation -= parent_joint_state.inherited_rotation
         end
       end
       

--- a/dsvlib/spriter_interface.rb
+++ b/dsvlib/spriter_interface.rb
@@ -287,4 +287,57 @@ class SpriterInterface
     
     return joint_states_for_pose
   end
+  
+  def self.initialize_joint_states_new(pose, skeleton)
+    joint_states_for_pose = []
+    
+    for joint_index in 0...pose.joint_changes.count
+      joint_state = JointState.new
+      joint = skeleton.joints[joint_index]
+      joint_change = pose.joint_changes[joint_index]
+      
+      joint_state.inherited_rotation = joint_change.rotation
+      joint_state.connected_rotation = joint_change.rotation
+      
+      if joint.parent_id != 0xFF
+        parent_joint = skeleton.joints[joint.parent_id]
+        parent_joint_state = joint_states_for_pose[joint.parent_id]
+        
+        if joint.copy_parent_visual_rotation # maybe this variable should be called something like "is_mobile" or "is_turning"
+          joint_state.inherited_rotation += parent_joint_state.inherited_rotation
+        else
+          joint_state.connected_rotation -= parent_joint_state.inherited_rotation
+        end
+      end
+      
+      case joint.positional_rotation
+        when 0
+          joint_state.x_pos = joint_change.distance
+          joint_state.y_pos = 0
+        when 1
+          joint_state.x_pos = 0
+          joint_state.y_pos = joint_change.distance
+        when 2
+          joint_state.x_pos = joint_change.distance * -1
+          joint_state.y_pos = 0
+        when 3
+          joint_state.x_pos = 0
+          joint_state.y_pos = joint_change.distance * -1
+        else # just to be safe
+          joint_state.x_pos = 0
+          joint_state.y_pos = 0
+      end
+      
+      # workaround for functions that need absolute positions
+      if joint.parent_id != 0xFF
+        joint_state.x_pos += parent_joint_state.x_pos
+        joint_state.y_pos += parent_joint_state.y_pos
+      end
+      
+      joint_states_for_pose << joint_state
+    end
+
+    return joint_states_for_pose
+  end
+  
 end

--- a/dsvlib/spriter_interface.rb
+++ b/dsvlib/spriter_interface.rb
@@ -328,12 +328,6 @@ class SpriterInterface
           joint_state.y_pos = 0
       end
       
-      # workaround for functions that need absolute positions
-      if joint.parent_id != 0xFF
-        joint_state.x_pos += parent_joint_state.x_pos
-        joint_state.y_pos += parent_joint_state.y_pos
-      end
-      
       joint_states_for_pose << joint_state
     end
 


### PR DESCRIPTION
Positions and rotates all the joints  correctly and doesn't use any trigonometry functions (will have to use those to draw them instead 😂). 
Looks like a more proper output that includes joint positions and rotations instead of only the already calculated positions.

Of course the results are incompatible with the existing code (joint positions are always relative to their parents and  relative rotation is included in the joint_state now) so it's currently unused.

I'm not sure if it's very useful... maybe makes it easier to export to Spriter or some other editor.
(apparently Spriter doesn't rotate the bones automatically if you just set their positions)