### PR TITLE
Improve new joint initialization function: keep rotation values between 0º and 360º

### DIFF
--- a/dsvedit/skeleton_editor_dialog.rb
+++ b/dsvedit/skeleton_editor_dialog.rb
@@ -210,8 +210,10 @@ class SkeletonEditorDialog < Qt::Dialog
         
         if joint.copy_parent_visual_rotation # maybe this variable should be called something like "is_mobile" or "is_turning"
           joint_state.inherited_rotation += parent_joint_state.inherited_rotation
+          joint_state.inherited_rotation &= 0xFFFF
         else
           joint_state.relative_rotation -= parent_joint_state.inherited_rotation
+          joint_state.relative_rotation &= 0xFFFF
         end
       end
       

--- a/dsvlib/spriter_interface.rb
+++ b/dsvlib/spriter_interface.rb
@@ -305,8 +305,10 @@ class SpriterInterface
         
         if joint.copy_parent_visual_rotation # maybe this variable should be called something like "is_mobile" or "is_turning"
           joint_state.inherited_rotation += parent_joint_state.inherited_rotation
+          joint_state.inherited_rotation &= 0xFFFF
         else
           joint_state.relative_rotation -= parent_joint_state.inherited_rotation
+          joint_state.relative_rotation &= 0xFFFF
         end
       end
       


### PR DESCRIPTION
Workaround for ruby's dynamic typing.